### PR TITLE
mock test revise

### DIFF
--- a/gcp-mock-test/test_create_disk_from_snapshot.py
+++ b/gcp-mock-test/test_create_disk_from_snapshot.py
@@ -1,7 +1,7 @@
 import os
-import pytest
-from unittest import mock
 import sys
+from unittest import mock
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 from snapshot_create.create_disk_from_snapshot import create_disk_from_snapshot
 from snapshot_create.utils import *
@@ -10,7 +10,12 @@ from snapshot_create.utils import *
 @mock.patch("snapshot_create.create_disk_from_snapshot.read_config", autospec=True)
 @mock.patch("snapshot_create.create_disk_from_snapshot.build", autospec=True)
 def test_create_disk_from_snapshot(mock_build, mock_read_config, mock_wait_for_disk_creation):
-    # Mock service and request objects
+    '''
+     Mock service and request objects
+     Note - mock object without spec might not be best practice
+     But the test case is a bit ocmplicate in this case for build discovery api
+     Hence I use mock.MagicMock
+    '''
     mock_service = mock.MagicMock()
     mock_disks = mock.MagicMock()
     mock_insert_request = mock.MagicMock()


### PR DESCRIPTION
This pull request introduces updates to the mock testing practices in the `gcp-mock-test` suite, including improvements to code clarity and the addition of new test cases. The changes primarily focus on refining the use of mocking techniques, adding comments for better understanding, and introducing a new test for snapshot creation with a zone.

### Improvements to mock testing practices:

* **Refactored imports for clarity**: Reorganized imports in `test_create_disk_from_snapshot.py` to align with best practices, ensuring `mock` is imported after `os` and `sys` modules.

* **Added detailed comments**: Included comments in `test_create_disk_from_snapshot.py` to explain the use of `mock.MagicMock` for complex scenarios, improving the readability of the test case.

* **Added warnings for mock usage**: Inserted a warning in `test_create_snapshot.py` about the author's limited expertise in mock testing, encouraging caution when using the code.

### New test case:

* **Introduced `test_create_snapshot_with_zone2`**: Added a new test in `test_create_snapshot.py` to validate snapshot creation with a zone, using fewer patches for cleaner and more maintainable code. This test demonstrates a trade-off between control and simplicity when using `autospec`.