### PR TITLE
add makefile and config updates

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,14 @@
+SRC_DIR = .
+PYTHON = python3
+COVERGAGE = coverage
+test:
+	$(PYTHON) -m unittest discover -s gcp-mock-test -p "*.py" -v
+	find . -name '*.pyc' -delete
+
+coverage:
+	$(PYTHON) -m coverage run -m unittest discover -s gcp-mock-test -p "*.py"
+	$(PYTHON) -m coverage report
+
+upgrade_req:
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install --upgrade -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pprintpp==0.4.0
 google-cloud-compute==1.29.0
 mock==5.2.0
 pytest==8.3.5
+coverage==7.8.0

--- a/snapshot_create/create_disk_config.yaml
+++ b/snapshot_create/create_disk_config.yaml
@@ -1,8 +1,7 @@
-
 disks:
-  - target_zone: us-central1-c
+  - target_zone: northamerica-northeast2-c
     disk_name: vm-2
     disk_type: pd-ssd
-    disk_size_gb: 10
-    target_project_id: unified-welder-454220-d5
-    src_snapshot_name: vm-us-central1-c-20250411060015-awqps5lv
+    disk_size_gb: 20
+    src_project_id: nodal-spot-453817-i7
+    src_snapshot_name: docker-deploy-northamerica-nort-20250415204839-ln3blgl8

--- a/snapshot_create/create_disk_from_snapshot.py
+++ b/snapshot_create/create_disk_from_snapshot.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import argparse
 from googleapiclient.discovery import build
-from .utils import wait_for_disk_creation, read_config
+from utils import wait_for_disk_creation, read_config
 import logging
 
 #  By default, the logging module in Python logs
@@ -61,9 +61,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     dry_run = args.dry_run
-
-    project_id = args.project_id
-    src_project_id = project_id
+    target_project_id = args.project_id
     configs = args.config
 
     # Example usage
@@ -73,7 +71,7 @@ if __name__ == "__main__":
         disk_name = disk["disk_name"]
         disk_type = disk["disk_type"]
         disk_size_gb = disk["disk_size_gb"]
-        target_project_id = disk["target_project_id"]
+        src_project_id = disk["src_project_id"]
         src_snapshot_name = disk["src_snapshot_name"]
         if dry_run:
             print(


### PR DESCRIPTION
This pull request introduces a `Makefile` for simplifying common tasks, updates the configuration for disk creation from snapshots, and refactors the Python script responsible for this process. Below is a summary of the most important changes:

### Build and Testing Enhancements:
* Added a `Makefile` with targets for running tests, generating coverage reports, and upgrading dependencies. This simplifies project setup and testing workflows. (`makefile`, [makefileR1-R14](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R1-R14))

### Configuration Updates:
* Updated `create_disk_config.yaml` to reflect changes in disk creation parameters:
  - Changed `target_zone` from `us-central1-c` to `northamerica-northeast2-c`.
  - Increased `disk_size_gb` from 10 to 20.
  - Updated `src_project_id` and `src_snapshot_name` to new values. (`snapshot_create/create_disk_config.yaml`, [snapshot_create/create_disk_config.yamlL1-R7](diffhunk://#diff-ecffc968856c90aaeea65ae6b463eed8e93b93704c4c93f847915cae8a261dd3L1-R7))

### Code Refactoring:
* Refactored import statements in `create_disk_from_snapshot.py` to use relative imports for compatibility. (`snapshot_create/create_disk_from_snapshot.py`, [snapshot_create/create_disk_from_snapshot.pyL5-R5](diffhunk://#diff-8f010b813da5bda636035e2b20c8eefe251ad86d907c3d1d0191fe0e1d5c1e57L5-R5))
* Replaced `project_id` with `target_project_id` for clarity and updated logic to correctly use `src_project_id` for source snapshots. (`snapshot_create/create_disk_from_snapshot.py`, [[1]](diffhunk://#diff-8f010b813da5bda636035e2b20c8eefe251ad86d907c3d1d0191fe0e1d5c1e57L64-R64) [[2]](diffhunk://#diff-8f010b813da5bda636035e2b20c8eefe251ad86d907c3d1d0191fe0e1d5c1e57L76-R74)